### PR TITLE
fix(SPac): Renamed `run` to `run_linux`, changed the script path & ch…

### DIFF
--- a/.spac/run
+++ b/.spac/run
@@ -1,1 +1,0 @@
-python3 src/elog.py

--- a/.spac/run_command
+++ b/.spac/run_command
@@ -1,1 +1,1 @@
-eidoslogos
+elog

--- a/.spac/run_linux
+++ b/.spac/run_linux
@@ -1,0 +1,1 @@
+python3 <REPO>/src/elog.py


### PR DESCRIPTION
…anged `run_command` from `eidoslogos` to `elog`, which is shorter`